### PR TITLE
feat: simplify install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ user/projects/myapp main* ⇣⇡ +20 -81 34,040 (79%)
 
 ## Installation
 
+```bash
+just install
+```
+
+<details>
+
+<summary>Manual install</summary>
+
 Build the binary and move it to `~/.claude/cc_pure`.
 
 ```bash
@@ -48,6 +56,8 @@ Add this to your `~/.claude/settings.json`:
   }
 }
 ```
+
+</details>
 
 ### Themes
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,15 @@
+default:
+    @just --list
+
+# Install cc_pure as the Claude Code statusline
+[group('setup')]
+install: build-release
+    mkdir -p ~/.claude
+    mv zig-out/bin/cc_pure ~/.claude/
+    @if [ ! -f ~/.claude/settings.json ]; then echo "{}" > ~/.claude/settings.json; fi
+    jq '.statusLine = {type: "command", command: "~/.claude/cc_pure"}' ~/.claude/settings.json > ~/.claude/settings.json.tmp && mv ~/.claude/settings.json.tmp ~/.claude/settings.json
+
+# Build a release version
+[group('build')]
+build-release:
+    zig build -Doptimize=ReleaseSafe

--- a/src/directory.zig
+++ b/src/directory.zig
@@ -163,6 +163,8 @@ test "simplify with relative path" {
 test "simplify handles irrelevant HOME variable" {
     const result = simplify("home/user/projects/myapp", "/s/d/f");
     try std.testing.expectEqualStrings("user/projects/myapp", result);
+    const result2 = simplify("home/user/projects/myapp", "/home/user2/");
+    try std.testing.expectEqualStrings("user/projects/myapp", result2);
 }
 
 test "simplify handles HOME without slash" {


### PR DESCRIPTION
`just install` is a more robust version of the previous installation (requires `jq`)